### PR TITLE
This adds a simple link to a test using Upholstery as front to d10n tools.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ COPY src ./src/
 RUN yarn install
 
 ENV NODE_ENV=production \
-  COUCH=https://upholstery.canadiana.ca
+  COUCH=https://upholstery.canadiana.ca \
+  PACKAGING=https://packaging-test.canadiana.ca
 
 RUN yarn run build
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ RUN yarn install
 
 ENV NODE_ENV=production \
   COUCH=https://upholstery.canadiana.ca \
-  PACKAGING=https://packaging-test.canadiana.ca
+  PACKAGING=https://packaging.canadiana.ca
 
 RUN yarn run build
 

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -21,7 +21,7 @@
         href="{process.env.COUCH}/cookie?token={$authState.token}"
         id="Futon"
         target="_blank">
-        Futon
+        Futon (Please do not edit unless you know what you are doing)
       </a>
     </li>
     <li>
@@ -29,7 +29,7 @@
         href="{process.env.PACKAGING}/cookie?token={$authState.token}"
         id="Packaging"
         target="_blank">
-        Packaging (test)
+        Packaging (legacy tools)
       </a>
     </li>
     <li>

--- a/src/routes/index.svelte
+++ b/src/routes/index.svelte
@@ -25,6 +25,14 @@
       </a>
     </li>
     <li>
+      <a
+        href="{process.env.PACKAGING}/cookie?token={$authState.token}"
+        id="Packaging"
+        target="_blank">
+        Packaging (test)
+      </a>
+    </li>
+    <li>
       <a href="/couchview">Couch view output</a>
     </li>
   </ul>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,6 +9,7 @@ const PurgecssPlugin = require("purgecss-webpack-plugin");
 
 const mode = process.env.NODE_ENV;
 const couch = process.env.COUCH;
+const packaging = process.env.PACKAGING;
 const dev = mode === "development";
 
 const alias = { svelte: path.resolve("node_modules", "svelte") };
@@ -71,7 +72,8 @@ module.exports = {
       new webpack.DefinePlugin({
         "process.browser": true,
         "process.env.NODE_ENV": JSON.stringify(mode),
-        "process.env.COUCH": JSON.stringify(couch)
+          "process.env.COUCH": JSON.stringify(couch),
+        "process.env.PACKAGING": JSON.stringify(packaging)
       }),
       ...plugins
     ],


### PR DESCRIPTION
Add support for a link to https://packaging.canadiana.ca/ #21

Pushed to docker.c7a.ca/sapindale:20191217 , and https://admin.canadiana.ca/

Spoke to Beth, and sent an email to everyone using these tools about the change.