### PR TITLE
Add in redirects, as everything is on Upholstery.

### DIFF
--- a/src/routes/accessLink/utilities.svelte
+++ b/src/routes/accessLink/utilities.svelte
@@ -20,7 +20,7 @@
       class="flex-1 text-white text-center text-xl bg-primary pt-8 py-2 m-2 h-24
       hover:border-black-600">
       <a
-        href="{process.env.PACKAGING}/cookie?token={$authState.token}"
+        href="{process.env.UPHOLSTERY}/cookie?redirect=/demo/&token={$authState.token}"
         id="Packaging"
         target="_blank">
         Packaging (legacy tools)
@@ -30,7 +30,7 @@
       class="flex-1 text-white text-center text-xl bg-primary pt-8 py-2 m-2 h-24
       hover:border-black-600">
       <a
-        href="{process.env.UPHOLSTERY}/cookie?token={$authState.token}"
+        href="{process.env.UPHOLSTERY}/cookie?redirect=/couch/_utils/&token={$authState.token}"
         id="Futon"
         target="_blank">
         Futon (Please do not edit unless you know what you are doing)


### PR DESCRIPTION
Once we have deployed the new Upholstery that contains the d10n demo files, we can use this PR to point to it.

This needs to be tested properly by a developer before going to production (I didn't set the full test environment up).