### PR TITLE
Concept for having a list of legacy tools

### DIFF
--- a/src/routes/accessLink/utilities.svelte
+++ b/src/routes/accessLink/utilities.svelte
@@ -19,12 +19,45 @@
     <div
       class="flex-1 text-white text-center text-xl bg-primary pt-8 py-2 m-2 h-24
       hover:border-black-600">
-      <a
-        href="{process.env.UPHOLSTERY}/cookie?redirect=/demo/&token={$authState.token}"
+        Packaging (legacy tools)
+      <ul>
+      <li><a
+        href="{process.env.UPHOLSTERY}/cookie?redirect=/demo/wipFindMoveCreate.html&token={$authState.token}"
         id="Packaging"
         target="_blank">
-        Packaging (legacy tools)
-      </a>
+        WIP Find/Move/Create
+      </a></li>
+      <li><a
+        href="{process.env.UPHOLSTERY}/cookie?redirect=/demo/wipProcessStatus.html&token={$authState.token}"
+        id="Packaging"
+        target="_blank">
+        WIP Process Status
+      </a></li>
+      <li><a
+        href="{process.env.UPHOLSTERY}/cookie?redirect=/demo/wipStartProcess.html&token={$authState.token}"
+        id="Packaging"
+        target="_blank">
+        WIP Start Process
+      </a></li>
+      <li><a
+        href="{process.env.UPHOLSTERY}/cookie?redirect=/demo/collectionManage.html&token={$authState.token}"
+        id="Packaging"
+        target="_blank">
+        Legacy Application Platform Collection Manager
+      </a></li>
+      <li><a
+        href="{process.env.UPHOLSTERY}/cookie?redirect=/demo/validationStatisticsTool.html&token={$authState.token}"
+        id="Packaging"
+        target="_blank">
+        Legacy Repository Statistics
+      </a></li>
+      <li><a
+        href="{process.env.UPHOLSTERY}/cookie?redirect=/demo/FD.html&token={$authState.token}"
+        id="Packaging"
+        target="_blank">
+        Find Duplicates in list
+      </a></li>
+      </ul>
     </div>
     <div
       class="flex-1 text-white text-center text-xl bg-primary pt-8 py-2 m-2 h-24


### PR DESCRIPTION
The old /demos/ tools would redirect to a Sharepoint document that Beth maintained.  I believe it would make it easier for staff to find the tools if we provided a menu of them within Sapindale.

With the recent cleanup there is only 6 tools remaining.

The remaining pages can be replaced with the CouchView tool once #34 is completed.