### PR TITLE
SlugResolver can choose between collection and manifest slugs

### DIFF
--- a/src/components/ArchivalManifest.svelte
+++ b/src/components/ArchivalManifest.svelte
@@ -644,7 +644,10 @@
             <dd>
               {#if selected[doc._id]}
                 <li class="slug">
-                  <SlugResolver label="New slug:" bind:value={slugs[doc._id]} />
+                  <SlugResolver
+                    label="New slug:"
+                    mode="manifest"
+                    bind:value={slugs[doc._id]} />
                 </li>
               {/if}
               {#if showdetails}

--- a/src/components/SlugResolver.svelte
+++ b/src/components/SlugResolver.svelte
@@ -44,7 +44,7 @@
 
   {#if state === 'FOUND'}
     ❌ :
-    <a href="/{slug.type}/{slug.noid}">Slug in use</a>
+    <a href="/{slug.type}/{encodeURIComponent(slug.noid)}">Slug in use</a>
   {:else if state === 'NOTFOUND'}
     ✅ : Slug available
   {:else if state === 'FAILED'}

--- a/src/components/SlugResolver.svelte
+++ b/src/components/SlugResolver.svelte
@@ -1,82 +1,55 @@
 <script>
   import { state as authState } from "../auth.js";
   import { createEventDispatcher, onMount } from "svelte";
-  import { resolveSlug } from "../api/collection.js";
+  import { resolveSlug as resolveCollectionSlug } from "../api/collection.js";
+  import { resolveSlug as resolveManifestSlug } from "../api/manifest.js";
   import spinner from "../spinner.svelte";
-  import SlugTypeAhead from "../components/SlugTypeAhead.svelte";
 
   let token = $authState.token;
-  const dispatch = createEventDispatcher();
   export let value = "",
-    label = "Slug";
-  let id, db;
-  let slugFound = false;
-  let slugCheckPending, slugList;
-  let slugId = "";
+    label = "Slug",
+    mode = "manifest",
+    state = "PENDING";
+
+  let slug;
+  let resolveMethod =
+    mode === "manifest" ? resolveManifestSlug : resolveCollectionSlug;
 
   onMount(async () => {
-    if (value != "") {
+    if (value !== "") {
       lookUpSlug();
     }
   });
 
   async function lookUpSlug() {
-    dispatch("deselected");
     try {
-      slugCheckPending = true;
-      slugList = await resolveSlug(token, value);
-      slugId = slugList.id;
-      slugCheckPending = false;
-      slugFound = !!slugId;
-    } catch (ignore) {}
-  }
-
-  async function slugSelect(event) {
-    dispatch("searched", { value });
+      state = "PENDING";
+      slug = await resolveMethod(token, value);
+      // errors will come with a "message" field.
+      // In the future, API requests should provide more explicit distinction
+      if (slug.message) {
+        state = "NOTFOUND";
+      } else {
+        state = "FOUND";
+      }
+    } catch (ignore) {
+      state = "FAILED";
+    }
   }
 </script>
 
-<style>
-  /* .lab {
-    width: 100%;
-  } */
-
-  .slug {
-    display: inline;
-  }
-  .spinnerbind {
-    display: inline;
-  }
-  .display {
-    padding-top: 5%;
-  }
-</style>
-
-<div class="slug">
+<span class="children-inline">
   <label for="slug">{label}</label>
-  <div class="spinnerbind">
-    <input
-      type="text"
-      bind:value
-      on:input={lookUpSlug}
-      on:change={slugSelect} />
+  <input type="text" bind:value on:input={lookUpSlug} />
 
-    {#if slugCheckPending}
-      <spinner />
-    {:else if slugFound && slugCheckPending != undefined && value != ''}
-      <span>❌ : Found in Database</span>
-    {:else if !slugFound && slugCheckPending != undefined && value != ''}
-      <span>✅ : Not found in Database</span>
-    {/if}
-  </div>
-  {#if slugFound}
-    <div class="display">
-      <h3>Slug Details</h3>
-      <ul>
-        {#each Object.keys(slugList) as item}
-          <li>{item}:{slugList[item]}</li>
-        {/each}
-      </ul>
-    </div>
+  {#if state === 'FOUND'}
+    ❌ :
+    <a href="/{slug.type}/{slug.noid}">Slug in use</a>
+  {:else if state === 'NOTFOUND'}
+    ✅ : Slug available
+  {:else if state === 'FAILED'}
+    Error searching for slugs.
+  {:else if value.length > 0}
+    <spinner />
   {/if}
-</div>
+</span>

--- a/src/routes/slug.svelte
+++ b/src/routes/slug.svelte
@@ -27,7 +27,7 @@
         <br />
         {Object.values(slug.label).join(' = ')} (Slug: {slug.id}) (NOID: {slug.noid})
         <br />
-        <a href="/{mode}/{slug.noid.replace('/', '%2F')}">Click here to edit</a>
+        <a href="/{mode}/{encodeURIComponent(slug.noid)}">Click here to edit</a>
       {:else}Something went wrong. {slug.message}{/if}
     {:else}Enter a slug by typing it.{/if}
   </p>


### PR DESCRIPTION
#72 
Also inlines its elements #73.

@DivyaKrishnan26 might want to look at how I refactored things in the SlugResolver component. I replaced the more complicated set of booleans with a `state` variable that has one of four settings: `PENDING`, `FOUND`, `NOTFOUND`, `FAILED`. This greatly simplified the template logic.

@RussellMcOrmond Let me know if this works for you. I haven't tried using the Archival Manifest tool at all, but I don't think the underlying logic has changed. SlugResolver also now exposes its `state`, as described above.